### PR TITLE
archiver vs mod patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ How many tickets do we purge every time we run? Depending on how you've configur
 
 
 # To Install as MOD and enable Archiving during any ticket delete:
-Open `/include/class.ticket.php` and add the "Signal::send" line below:
+Uncomment line ~45 of this plugin's config.php to allow using it without the ticket-delete MOD (see below). Line 45 is the one that adds the error message 'The signal is not being sent from class.tickets.php'. That checks to make sure you've followed the next step properly.
+
+Open `/include/class.ticket.php` and add the "Signal::send" line shown below (inside the delete function found around line: ~2700):
 
 ```php
     function delete($comments='') {

--- a/config.php
+++ b/config.php
@@ -42,7 +42,7 @@ class ArchiverPluginConfig extends PluginConfig {
 		// Attempt to find our signal string:
 		if (preg_match ( '/ticket\.before\.delete/', file_get_contents ( $class_ticket_php ) ) == FALSE) {
 			// We are unable to detect tickets being deleted! shit!
-			$errors ['err'] .= "\nThe signal is not being sent from class.tickets.php, check README.";
+			// $errors ['err'] .= "\nThe signal is not being sent from class.tickets.php, check README."; //uncomment this to verify the MOD has been properly put in place (see Readme.md)
 		}
 		if (isset ( $errors ['err'] ))
 			return false;


### PR DESCRIPTION
These changes make the instructions consistent with the plugin's behavior. You can drop it in place and it will work as an archiver. If you want the delete mod, you have to make changes to the class file and it's helpful to also uncomment the verification error in the plugin config file. But because the verification error prevents using it as a simple drop-in plugin archiver, these changes are needed for a good experience.